### PR TITLE
main: simpler import procedure

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,29 +1,18 @@
 package main
 
 import (
-	"github.com/dcw303/crenshaw-go/chapter16"
+	pkg "github.com/dcw303/crenshaw-go/chapter01"
 	"github.com/dcw303/crenshaw-go/util"
 	"github.com/nsf/termbox-go"
 )
 
-//1. Import the chapter you want to run
-
-//2. Execute the Go() func on the package for the chapter. This is:
-
-// chapter 01: cradle
-// chapter 02/03/06/06b/09/09b: parse
-// chapter 04: interpret
-// chapter 05: branch
-// chapter 07/07b: kiss
-// chapter 10/11/12/12b: tiny
-// chapter 13/13b: calls
-// chapter 14: types
-// chapter 15/16: test
+// Import the chapter you want to run:
+// "github.com/dcw303/crenshaw-go/chapter02"
 
 func main() {
 	defer termbox.Close()
 	defer closeLoop()
-	test.Go()
+	pkg.Go()
 }
 
 func closeLoop() {


### PR DESCRIPTION
This CL modifies main.go to use a named import statement so we don't
have to modify the package name _and_ the import statement.
