### PR TITLE
all: use go-run to run chapters code

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,5 +4,7 @@ A go implementation of [Let's Build a Compiler, by Jack Crenshaw](http://compile
 
 How to run:
 
-Chapters 1-16 have different executables. Modify main.go in the root directory to point to the appropriate package. Package names are listed in that file.
-
+```sh
+$> cd chapterXX
+$> go run main.go
+```

--- a/chapter01/main.go
+++ b/chapter01/main.go
@@ -1,15 +1,12 @@
-package main
+//+build ignore
 
-//go:generate go run ./gen-main.go
+package main
 
 import (
 	pkg "github.com/dcw303/crenshaw-go/chapter01"
 	"github.com/dcw303/crenshaw-go/util"
 	"github.com/nsf/termbox-go"
 )
-
-// Import the chapter you want to run:
-// "github.com/dcw303/crenshaw-go/chapter02"
 
 func main() {
 	defer termbox.Close()

--- a/chapter02/main.go
+++ b/chapter02/main.go
@@ -1,15 +1,12 @@
+//+build ignore
+
 package main
 
-//go:generate go run ./gen-main.go
-
 import (
-	pkg "github.com/dcw303/crenshaw-go/chapter01"
+	pkg "github.com/dcw303/crenshaw-go/chapter02"
 	"github.com/dcw303/crenshaw-go/util"
 	"github.com/nsf/termbox-go"
 )
-
-// Import the chapter you want to run:
-// "github.com/dcw303/crenshaw-go/chapter02"
 
 func main() {
 	defer termbox.Close()

--- a/chapter03/main.go
+++ b/chapter03/main.go
@@ -1,15 +1,12 @@
+//+build ignore
+
 package main
 
-//go:generate go run ./gen-main.go
-
 import (
-	pkg "github.com/dcw303/crenshaw-go/chapter01"
+	pkg "github.com/dcw303/crenshaw-go/chapter03"
 	"github.com/dcw303/crenshaw-go/util"
 	"github.com/nsf/termbox-go"
 )
-
-// Import the chapter you want to run:
-// "github.com/dcw303/crenshaw-go/chapter02"
 
 func main() {
 	defer termbox.Close()

--- a/chapter04/main.go
+++ b/chapter04/main.go
@@ -1,15 +1,12 @@
+//+build ignore
+
 package main
 
-//go:generate go run ./gen-main.go
-
 import (
-	pkg "github.com/dcw303/crenshaw-go/chapter01"
+	pkg "github.com/dcw303/crenshaw-go/chapter04"
 	"github.com/dcw303/crenshaw-go/util"
 	"github.com/nsf/termbox-go"
 )
-
-// Import the chapter you want to run:
-// "github.com/dcw303/crenshaw-go/chapter02"
 
 func main() {
 	defer termbox.Close()

--- a/chapter05/main.go
+++ b/chapter05/main.go
@@ -1,15 +1,12 @@
+//+build ignore
+
 package main
 
-//go:generate go run ./gen-main.go
-
 import (
-	pkg "github.com/dcw303/crenshaw-go/chapter01"
+	pkg "github.com/dcw303/crenshaw-go/chapter05"
 	"github.com/dcw303/crenshaw-go/util"
 	"github.com/nsf/termbox-go"
 )
-
-// Import the chapter you want to run:
-// "github.com/dcw303/crenshaw-go/chapter02"
 
 func main() {
 	defer termbox.Close()

--- a/chapter06/main.go
+++ b/chapter06/main.go
@@ -1,15 +1,12 @@
+//+build ignore
+
 package main
 
-//go:generate go run ./gen-main.go
-
 import (
-	pkg "github.com/dcw303/crenshaw-go/chapter01"
+	pkg "github.com/dcw303/crenshaw-go/chapter06"
 	"github.com/dcw303/crenshaw-go/util"
 	"github.com/nsf/termbox-go"
 )
-
-// Import the chapter you want to run:
-// "github.com/dcw303/crenshaw-go/chapter02"
 
 func main() {
 	defer termbox.Close()

--- a/chapter06b/main.go
+++ b/chapter06b/main.go
@@ -1,15 +1,12 @@
+//+build ignore
+
 package main
 
-//go:generate go run ./gen-main.go
-
 import (
-	pkg "github.com/dcw303/crenshaw-go/chapter01"
+	pkg "github.com/dcw303/crenshaw-go/chapter06b"
 	"github.com/dcw303/crenshaw-go/util"
 	"github.com/nsf/termbox-go"
 )
-
-// Import the chapter you want to run:
-// "github.com/dcw303/crenshaw-go/chapter02"
 
 func main() {
 	defer termbox.Close()

--- a/chapter07/main.go
+++ b/chapter07/main.go
@@ -1,15 +1,12 @@
+//+build ignore
+
 package main
 
-//go:generate go run ./gen-main.go
-
 import (
-	pkg "github.com/dcw303/crenshaw-go/chapter01"
+	pkg "github.com/dcw303/crenshaw-go/chapter07"
 	"github.com/dcw303/crenshaw-go/util"
 	"github.com/nsf/termbox-go"
 )
-
-// Import the chapter you want to run:
-// "github.com/dcw303/crenshaw-go/chapter02"
 
 func main() {
 	defer termbox.Close()

--- a/chapter07b/main.go
+++ b/chapter07b/main.go
@@ -1,15 +1,12 @@
+//+build ignore
+
 package main
 
-//go:generate go run ./gen-main.go
-
 import (
-	pkg "github.com/dcw303/crenshaw-go/chapter01"
+	pkg "github.com/dcw303/crenshaw-go/chapter07b"
 	"github.com/dcw303/crenshaw-go/util"
 	"github.com/nsf/termbox-go"
 )
-
-// Import the chapter you want to run:
-// "github.com/dcw303/crenshaw-go/chapter02"
 
 func main() {
 	defer termbox.Close()

--- a/chapter09/main.go
+++ b/chapter09/main.go
@@ -1,15 +1,12 @@
+//+build ignore
+
 package main
 
-//go:generate go run ./gen-main.go
-
 import (
-	pkg "github.com/dcw303/crenshaw-go/chapter01"
+	pkg "github.com/dcw303/crenshaw-go/chapter09"
 	"github.com/dcw303/crenshaw-go/util"
 	"github.com/nsf/termbox-go"
 )
-
-// Import the chapter you want to run:
-// "github.com/dcw303/crenshaw-go/chapter02"
 
 func main() {
 	defer termbox.Close()

--- a/chapter09b/main.go
+++ b/chapter09b/main.go
@@ -1,15 +1,12 @@
+//+build ignore
+
 package main
 
-//go:generate go run ./gen-main.go
-
 import (
-	pkg "github.com/dcw303/crenshaw-go/chapter01"
+	pkg "github.com/dcw303/crenshaw-go/chapter09b"
 	"github.com/dcw303/crenshaw-go/util"
 	"github.com/nsf/termbox-go"
 )
-
-// Import the chapter you want to run:
-// "github.com/dcw303/crenshaw-go/chapter02"
 
 func main() {
 	defer termbox.Close()

--- a/chapter10/main.go
+++ b/chapter10/main.go
@@ -1,15 +1,12 @@
+//+build ignore
+
 package main
 
-//go:generate go run ./gen-main.go
-
 import (
-	pkg "github.com/dcw303/crenshaw-go/chapter01"
+	pkg "github.com/dcw303/crenshaw-go/chapter10"
 	"github.com/dcw303/crenshaw-go/util"
 	"github.com/nsf/termbox-go"
 )
-
-// Import the chapter you want to run:
-// "github.com/dcw303/crenshaw-go/chapter02"
 
 func main() {
 	defer termbox.Close()

--- a/chapter11/main.go
+++ b/chapter11/main.go
@@ -1,15 +1,12 @@
+//+build ignore
+
 package main
 
-//go:generate go run ./gen-main.go
-
 import (
-	pkg "github.com/dcw303/crenshaw-go/chapter01"
+	pkg "github.com/dcw303/crenshaw-go/chapter11"
 	"github.com/dcw303/crenshaw-go/util"
 	"github.com/nsf/termbox-go"
 )
-
-// Import the chapter you want to run:
-// "github.com/dcw303/crenshaw-go/chapter02"
 
 func main() {
 	defer termbox.Close()

--- a/chapter12/main.go
+++ b/chapter12/main.go
@@ -1,15 +1,12 @@
+//+build ignore
+
 package main
 
-//go:generate go run ./gen-main.go
-
 import (
-	pkg "github.com/dcw303/crenshaw-go/chapter01"
+	pkg "github.com/dcw303/crenshaw-go/chapter12"
 	"github.com/dcw303/crenshaw-go/util"
 	"github.com/nsf/termbox-go"
 )
-
-// Import the chapter you want to run:
-// "github.com/dcw303/crenshaw-go/chapter02"
 
 func main() {
 	defer termbox.Close()

--- a/chapter12b/main.go
+++ b/chapter12b/main.go
@@ -1,15 +1,12 @@
+//+build ignore
+
 package main
 
-//go:generate go run ./gen-main.go
-
 import (
-	pkg "github.com/dcw303/crenshaw-go/chapter01"
+	pkg "github.com/dcw303/crenshaw-go/chapter12b"
 	"github.com/dcw303/crenshaw-go/util"
 	"github.com/nsf/termbox-go"
 )
-
-// Import the chapter you want to run:
-// "github.com/dcw303/crenshaw-go/chapter02"
 
 func main() {
 	defer termbox.Close()

--- a/chapter13/main.go
+++ b/chapter13/main.go
@@ -1,15 +1,12 @@
+//+build ignore
+
 package main
 
-//go:generate go run ./gen-main.go
-
 import (
-	pkg "github.com/dcw303/crenshaw-go/chapter01"
+	pkg "github.com/dcw303/crenshaw-go/chapter13"
 	"github.com/dcw303/crenshaw-go/util"
 	"github.com/nsf/termbox-go"
 )
-
-// Import the chapter you want to run:
-// "github.com/dcw303/crenshaw-go/chapter02"
 
 func main() {
 	defer termbox.Close()

--- a/chapter13b/main.go
+++ b/chapter13b/main.go
@@ -1,15 +1,12 @@
+//+build ignore
+
 package main
 
-//go:generate go run ./gen-main.go
-
 import (
-	pkg "github.com/dcw303/crenshaw-go/chapter01"
+	pkg "github.com/dcw303/crenshaw-go/chapter13b"
 	"github.com/dcw303/crenshaw-go/util"
 	"github.com/nsf/termbox-go"
 )
-
-// Import the chapter you want to run:
-// "github.com/dcw303/crenshaw-go/chapter02"
 
 func main() {
 	defer termbox.Close()

--- a/chapter14/main.go
+++ b/chapter14/main.go
@@ -1,15 +1,12 @@
+//+build ignore
+
 package main
 
-//go:generate go run ./gen-main.go
-
 import (
-	pkg "github.com/dcw303/crenshaw-go/chapter01"
+	pkg "github.com/dcw303/crenshaw-go/chapter14"
 	"github.com/dcw303/crenshaw-go/util"
 	"github.com/nsf/termbox-go"
 )
-
-// Import the chapter you want to run:
-// "github.com/dcw303/crenshaw-go/chapter02"
 
 func main() {
 	defer termbox.Close()

--- a/chapter15/main.go
+++ b/chapter15/main.go
@@ -1,15 +1,12 @@
+//+build ignore
+
 package main
 
-//go:generate go run ./gen-main.go
-
 import (
-	pkg "github.com/dcw303/crenshaw-go/chapter01"
+	pkg "github.com/dcw303/crenshaw-go/chapter15"
 	"github.com/dcw303/crenshaw-go/util"
 	"github.com/nsf/termbox-go"
 )
-
-// Import the chapter you want to run:
-// "github.com/dcw303/crenshaw-go/chapter02"
 
 func main() {
 	defer termbox.Close()

--- a/chapter16/main.go
+++ b/chapter16/main.go
@@ -1,15 +1,12 @@
+//+build ignore
+
 package main
 
-//go:generate go run ./gen-main.go
-
 import (
-	pkg "github.com/dcw303/crenshaw-go/chapter01"
+	pkg "github.com/dcw303/crenshaw-go/chapter16"
 	"github.com/dcw303/crenshaw-go/util"
 	"github.com/nsf/termbox-go"
 )
-
-// Import the chapter you want to run:
-// "github.com/dcw303/crenshaw-go/chapter02"
 
 func main() {
 	defer termbox.Close()

--- a/gen-main.go
+++ b/gen-main.go
@@ -1,0 +1,67 @@
+//+build ignore
+
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"path/filepath"
+)
+
+const tmpl = `//+build ignore
+
+package main
+
+import (
+	pkg "github.com/dcw303/crenshaw-go/%s"
+	"github.com/dcw303/crenshaw-go/util"
+	"github.com/nsf/termbox-go"
+)
+
+func main() {
+	defer termbox.Close()
+	defer closeLoop()
+	pkg.Go()
+}
+
+func closeLoop() {
+	util.WriteLine("*** Execution Complete - Hit <Enter> to exit ***")
+	for r := util.Read(); r != 0x0D; r = util.Read() {
+	}
+
+}
+`
+
+func main() {
+	for _, chapter := range []string{
+		"chapter01",
+		"chapter02",
+		"chapter03",
+		"chapter04",
+		"chapter05",
+		"chapter06",
+		"chapter06b",
+		"chapter07",
+		"chapter07b",
+		"chapter09",
+		"chapter09b",
+		"chapter10",
+		"chapter11",
+		"chapter12",
+		"chapter12b",
+		"chapter13",
+		"chapter13b",
+		"chapter14",
+		"chapter15",
+		"chapter16",
+	} {
+		fname := filepath.Join(chapter, "main.go")
+
+		err := ioutil.WriteFile(fname, []byte(fmt.Sprintf(tmpl, chapter)), 0644)
+
+		if err != nil {
+			log.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
Instead of painfully modifying the root main.go file, put a main.go
file under each chapterXX directory, automatically go-generated from
the root main.go one.
